### PR TITLE
Add MIT license

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.5.5
 Author: Olivier Banville <oli.banville@gmail.com>
 Maintainer: Olivier Banville <oli.banville@gmail.com>
 Description: Package d'accès à hublot
-License:
+License:MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: hublot
 Type: Package
 Title: Package d'accès à hublot
-Version: 1.5.5
+Version: 1.5.6
 Author: Olivier Banville <oli.banville@gmail.com>
 Maintainer: Olivier Banville <oli.banville@gmail.com>
 Description: Package d'accès à hublot
-License:MIT + file LICENSE
+License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2023
+COPYRIGHT HOLDER: hublot authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2023 hublot authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
@olichose123 Ça fonctionne si ce package est assigné la license MIT?

Ça va permettre d'automatiser les tests à l'aide de GitHub Actions. `clessnverse` utilise déjà la license MIT.